### PR TITLE
fix ca_cert::update in resource ca_cert::ca

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -43,6 +43,7 @@ define ca_cert::ca (
 ) {
 
   include ::ca_cert::params
+  include ::ca_cert::update
 
   if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !is_string($ca_text) {
     fail('ca_text is required if source is set to text')


### PR DESCRIPTION
due to the bug:
Could not find resource 'Class[Ca_cert::Update]' in parameter 'notify' at /etc/puppetlabs/code/environments/*******/modules/ca_cert/manifests/ca.pp:98
on puppetrun if only following code is declared in the .pp-file:

  ca_cert::ca { '****':
    ensure => 'trusted',
    source => "puppet:///modules/standard/ca_cert/****",
  }