### PR TITLE
fix: switch to namespaced function stdlib::ensure_packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class ca_cert (
   }
 
   if $install_package {
-    ensure_packages($package_name, { ensure => $package_ensure })
+    stdlib::ensure_packages($package_name, { ensure => $package_ensure })
 
     if $package_ensure != 'absent' {
       Package[$package_name] -> Ca_cert::Ca <| |>


### PR DESCRIPTION
The function ensure_packages is deprecated.

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, deprecation. ensure_packages. This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/environments/production/forge/ca_cert/manifests/init.pp", 79]
...
```