### PR TITLE
Cleanup Debian defaults

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,22 +9,12 @@ class ca_cert::params {
       $trusted_cert_dir  = '/usr/local/share/ca-certificates'
       $distrusted_cert_dir = undef
       $update_cmd        = 'update-ca-certificates'
-      $cert_dir_group    = 'staff'
+      $cert_dir_group    = 'root'
+      $cert_dir_mode     = '0755'
       $ca_file_group     = 'root'
-      $ca_file_mode      = '0444'
+      $ca_file_mode      = '0644'
       $ca_file_extension = 'crt'
       $package_name      = 'ca-certificates'
-      case $facts['os']['name'] {
-        'Ubuntu': {
-          $cert_dir_mode     = '0755'
-        }
-        /(Debian|Kali)/: {
-          $cert_dir_mode     = '2665'
-        }
-        default: {
-          $cert_dir_mode     = '0755'
-        }
-      }
     }
     'RedHat': {
       $trusted_cert_dir    = '/etc/pki/ca-trust/source/anchors'

--- a/spec/classes/ca_cert_spec.rb
+++ b/spec/classes/ca_cert_spec.rb
@@ -5,8 +5,6 @@ describe 'ca_cert', type: :class do
     case facts[:os]['family']
     when 'Debian'
       trusted_cert_dir = '/usr/local/share/ca-certificates'
-      cert_dir_group   = 'staff'
-      cert_dir_mode = '2665' if facts[:os]['name'] == 'Debian'
     when 'RedHat'
       trusted_cert_dir = '/etc/pki/ca-trust/source/anchors'
       update_cmd       = 'update-ca-trust extract'


### PR DESCRIPTION
As mentioned in https://github.com/voxpupuli/puppet-ca_cert/pull/81#discussion_r1595753502 the debian defaults don't align with distro packages.
This PR corrects this and also align ca_file_mode across all distros.
