### PR TITLE
Support distrusting ca's on Debian; Changed ca_cert::ca parameter names and meaning

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,22 +6,17 @@
 
 ### Classes
 
-* [`ca_cert`](#ca_cert): This module manages the user defined certificate authority (CA)
-certificates on the server. On OSes that support a distrusted
-folder the module also manages distrusting system default CA certificates.
+* [`ca_cert`](#ca_cert): This module manages the shared system-wide truststore.
 
 ### Defined types
 
-* [`ca_cert::ca`](#ca_cert--ca): Manage a user defined CA Certificate on a system.
-On OSes that support distrusting pre-installed CAs this can be managed as well.
+* [`ca_cert::ca`](#ca_cert--ca): Manage a CA Certificate in the the shared system-wide truststore.
 
 ## Classes
 
 ### <a name="ca_cert"></a>`ca_cert`
 
-This module manages the user defined certificate authority (CA)
-certificates on the server. On OSes that support a distrusted
-folder the module also manages distrusting system default CA certificates.
+This module manages the shared system-wide truststore.
 
 #### Examples
 
@@ -60,6 +55,7 @@ The following parameters are available in the `ca_cert` class:
 * [`update_cmd`](#-ca_cert--update_cmd)
 * [`trusted_cert_dir`](#-ca_cert--trusted_cert_dir)
 * [`distrusted_cert_dir`](#-ca_cert--distrusted_cert_dir)
+* [`ca_certificates_conf`](#-ca_cert--ca_certificates_conf)
 * [`install_package`](#-ca_cert--install_package)
 * [`package_ensure`](#-ca_cert--package_ensure)
 * [`package_name`](#-ca_cert--package_name)
@@ -91,6 +87,15 @@ Default provided by Hiera for supported Operating Systems.
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Absolute directory path to the folder containing distrusted certificates.
+Default provided by Hiera for supported Operating Systems.
+
+Default value: `undef`
+
+##### <a name="-ca_cert--ca_certificates_conf"></a>`ca_certificates_conf`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Some distros use a configuration file to mark distrusted certificates.
 Default provided by Hiera for supported Operating Systems.
 
 Default value: `undef`
@@ -198,8 +203,7 @@ Default value: `{}`
 
 ### <a name="ca_cert--ca"></a>`ca_cert::ca`
 
-Manage a user defined CA Certificate on a system.
-On OSes that support distrusting pre-installed CAs this can be managed as well.
+Manage a CA Certificate in the the shared system-wide truststore.
 
 #### Examples
 
@@ -215,55 +219,53 @@ ca_cert::ca { 'globalsign_org_intermediate':
 
 The following parameters are available in the `ca_cert::ca` defined type:
 
-* [`ca_text`](#-ca_cert--ca--ca_text)
-* [`source`](#-ca_cert--ca--source)
 * [`ensure`](#-ca_cert--ca--ensure)
-* [`verify_https_cert`](#-ca_cert--ca--verify_https_cert)
+* [`content`](#-ca_cert--ca--content)
+* [`source`](#-ca_cert--ca--source)
+* [`allow_insecure_source`](#-ca_cert--ca--allow_insecure_source)
 * [`checksum`](#-ca_cert--ca--checksum)
 * [`checksum_type`](#-ca_cert--ca--checksum_type)
 
-##### <a name="-ca_cert--ca--ca_text"></a>`ca_text`
+##### <a name="-ca_cert--ca--ensure"></a>`ensure`
 
-Data type: `Optional[String]`
+Data type: `Enum['present', 'absent', 'trusted', 'distrusted']`
 
-The text of the CA certificate to install. Required if text is the source
-(default). If a different source is specified this parameter is ignored.
+Whether or not the CA certificate should be on a system or not.
+- `present`/`absent` is used to manage local/none default CAs.
+- `trusted`/`distrusted` is used to manage system CAs.
+
+Default value: `'present'`
+
+##### <a name="-ca_cert--ca--content"></a>`content`
+
+Data type: `Optional[String[1]]`
+
+PEM formatted certificate content
+This attribute is mutually exclusive with `source`
 
 Default value: `undef`
 
 ##### <a name="-ca_cert--ca--source"></a>`source`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Where the CA certificate should be retrieved from. text, http, https, ftp,
-file, and puppet protocols/sources are supported. If text, then the ca_text parameter
-is also required. Defaults to text.
+A source certificate, which will be copied into place on the local system.
+This attribute is mutually exclusive with `content`
+Uri support, see puppet-archive.
 
-Default value: `'text'`
+Default value: `undef`
 
-##### <a name="-ca_cert--ca--ensure"></a>`ensure`
-
-Data type: `Enum['present', 'trusted', 'distrusted', 'absent']`
-
-Whether or not the CA certificate should be on a system or not. Valid
-values are trusted, present, distrusted, and absent. Note: untrusted is
-not supported on Debian based systems - using it will log a warning
-and treat it the same as absent. (defaults to trusted)
-
-Default value: `'trusted'`
-
-##### <a name="-ca_cert--ca--verify_https_cert"></a>`verify_https_cert`
+##### <a name="-ca_cert--ca--allow_insecure_source"></a>`allow_insecure_source`
 
 Data type: `Boolean`
 
-When retrieving a certificate whether or not to validate the CA of the
-source. (defaults to true)
+Wether to allow insecure download or not.
 
-Default value: `true`
+Default value: `false`
 
 ##### <a name="-ca_cert--ca--checksum"></a>`checksum`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 The checksum of the file. (defaults to undef)
 

--- a/data/Archlinux-family.yaml
+++ b/data/Archlinux-family.yaml
@@ -1,4 +1,4 @@
 ---
 ca_cert::update_cmd:          'trust extract-compat'
-ca_cert::trusted_cert_dir:    '/etc/ca-certificates/trust-source/anchors/'
+ca_cert::trusted_cert_dir:    '/etc/ca-certificates/trust-source/anchors'
 ca_cert::distrusted_cert_dir: '/etc/ca-certificates/trust-source/blacklist'

--- a/data/Archlinux-family.yaml
+++ b/data/Archlinux-family.yaml
@@ -1,4 +1,4 @@
 ---
 ca_cert::update_cmd:          'trust extract-compat'
 ca_cert::trusted_cert_dir:    '/etc/ca-certificates/trust-source/anchors'
-ca_cert::distrusted_cert_dir: '/etc/ca-certificates/trust-source/blacklist'
+ca_cert::distrusted_cert_dir: '/etc/ca-certificates/trust-source/blocklist'

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,3 +1,4 @@
 ---
-ca_cert::update_cmd:          'update-ca-certificates'
-ca_cert::trusted_cert_dir:    '/usr/local/share/ca-certificates'
+ca_cert::update_cmd:           'update-ca-certificates'
+ca_cert::trusted_cert_dir:     '/usr/local/share/ca-certificates'
+ca_cert::ca_certificates_conf: '/etc/ca-certificates.conf'

--- a/data/RedHat-family-9.yaml
+++ b/data/RedHat-family-9.yaml
@@ -1,0 +1,2 @@
+---
+ca_cert::distrusted_cert_dir: '/etc/pki/ca-trust/source/blocklist'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,5 @@
 # @summary
-#   This module manages the user defined certificate authority (CA)
-#   certificates on the server. On OSes that support a distrusted
-#   folder the module also manages distrusting system default CA certificates.
+#   This module manages the shared system-wide truststore.
 #
 # @example Basic usage
 #   class { 'ca_cert': }
@@ -32,6 +30,10 @@
 #
 # @param distrusted_cert_dir
 #   Absolute directory path to the folder containing distrusted certificates.
+#   Default provided by Hiera for supported Operating Systems.
+#
+# @param ca_certificates_conf
+#   Some distros use a configuration file to mark distrusted certificates.
 #   Default provided by Hiera for supported Operating Systems.
 #
 # @param install_package
@@ -82,6 +84,7 @@ class ca_cert (
   String[1] $update_cmd,
   Stdlib::Absolutepath $trusted_cert_dir,
   Optional[Stdlib::Absolutepath] $distrusted_cert_dir = undef,
+  Optional[Stdlib::Absolutepath] $ca_certificates_conf = undef,
   Boolean $install_package = true,
   Stdlib::Ensure::Package $package_ensure = 'installed',
   String[1] $package_name = 'ca-certificates',

--- a/spec/acceptance/ca_cert_ca_spec.rb
+++ b/spec/acceptance/ca_cert_ca_spec.rb
@@ -18,7 +18,7 @@ when 'RedHat'
 when 'Archlinux'
   trusted_ca_file_remote = '/etc/ca-certificates/trust-source/anchors/DigiCert_G5_TLS_ECC_SHA384_2021_CA1.crt'
   trusted_ca_file_text = '/etc/ca-certificates/trust-source/anchors/InCommon.crt'
-  untrusted_ca_file_remote = '/etc/ca-certificates/trust-source/blacklist/DigiCert_Global_Root_G3.crt'
+  untrusted_ca_file_remote = '/etc/ca-certificates/trust-source/blocklist/DigiCert_Global_Root_G3.crt'
   ca_certificates_bundle = '/etc/ca-certificates/extracted/tls-ca-bundle.pem'
 end
 

--- a/spec/acceptance/ca_cert_ca_spec.rb
+++ b/spec/acceptance/ca_cert_ca_spec.rb
@@ -9,7 +9,11 @@ when 'Debian'
 when 'RedHat'
   trusted_ca_file_remote = '/etc/pki/ca-trust/source/anchors/DigiCert_G5_TLS_ECC_SHA384_2021_CA1.crt'
   trusted_ca_file_text = '/etc/pki/ca-trust/source/anchors/InCommon.crt'
-  untrusted_ca_file_remote = '/etc/pki/ca-trust/source/blacklist/DigiCert_Global_Root_G3.crt'
+  untrusted_ca_file_remote = if host_inventory['facter']['os']['release']['major'] < '9'
+                               '/etc/pki/ca-trust/source/blacklist/DigiCert_Global_Root_G3.crt'
+                             else
+                               '/etc/pki/ca-trust/source/blocklist/DigiCert_Global_Root_G3.crt'
+                             end
   ca_certificates_bundle = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
 when 'Archlinux'
   trusted_ca_file_remote = '/etc/ca-certificates/trust-source/anchors/DigiCert_G5_TLS_ECC_SHA384_2021_CA1.crt'

--- a/spec/classes/ca_cert_spec.rb
+++ b/spec/classes/ca_cert_spec.rb
@@ -9,7 +9,7 @@ describe 'ca_cert', type: :class do
       trusted_cert_dir = '/etc/pki/ca-trust/source/anchors'
       update_cmd       = 'update-ca-trust extract'
     when 'Archlinux'
-      trusted_cert_dir = '/etc/ca-certificates/trust-source/anchors/'
+      trusted_cert_dir = '/etc/ca-certificates/trust-source/anchors'
       update_cmd       = 'trust extract-compat'
     when 'Suse'
       trusted_cert_dir = '/etc/pki/trust/anchors'
@@ -63,8 +63,10 @@ describe 'ca_cert', type: :class do
 
       it { is_expected.to contain_ca_cert__ca('ca1') } # from ./spec/fixtures/hiera
       it { is_expected.to contain_ca_cert__ca('ca2') } # from ./spec/fixtures/hiera
-      it { is_expected.to contain_file('ca1.crt').with_source('puppet:///modules/ca_cert/ca1.pem') }
-      it { is_expected.to contain_file('ca2.crt').with_source('puppet:///modules/ca_cert/ca2.pem') }
+      it { is_expected.to contain_archive("#{trusted_cert_dir}/ca1.crt").with_source('puppet:///modules/ca_cert/ca1.pem') }
+      it { is_expected.to contain_archive("#{trusted_cert_dir}/ca2.crt").with_source('puppet:///modules/ca_cert/ca2.pem') }
+      it { is_expected.to contain_file("#{trusted_cert_dir}/ca1.crt").with_ensure('file') }
+      it { is_expected.to contain_file("#{trusted_cert_dir}/ca2.crt").with_ensure('file') }
 
       context 'with always_update_certs set to true' do
         let(:params) { { always_update_certs: true } }

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe 'ca_cert::ca', type: :define do
   let(:title) { 'Globalsign_Org_Intermediate' }
-  let(:pre_condition) { 'class {"ca_cert": }' }
+  let(:pre_condition) do
+    'class {"ca_cert":
+      ca_certs => {},
+    }'
+  end
 
   on_supported_os.sort.each do |os, facts|
     # define os specific defaults
@@ -13,7 +17,7 @@ describe 'ca_cert::ca', type: :define do
       trusted_cert_dir    = '/etc/pki/ca-trust/source/anchors'
       distrusted_cert_dir = '/etc/pki/ca-trust/source/blacklist'
     when 'Archlinux'
-      trusted_cert_dir    = '/etc/ca-certificates/trust-source/anchors/'
+      trusted_cert_dir    = '/etc/ca-certificates/trust-source/anchors'
       distrusted_cert_dir = '/etc/ca-certificates/trust-source/blacklist'
     when 'Suse'
       trusted_cert_dir    = '/etc/pki/trust/anchors'
@@ -29,28 +33,21 @@ describe 'ca_cert::ca', type: :define do
       let(:facts) { facts }
 
       context 'with default values for parameters' do
-        it { expect { is_expected.to contain_class(:subject) }.to raise_error(Puppet::Error, %r{ca_text is required if source is set to text}) }
+        it { is_expected.to compile.and_raise_error(%r{Either `source` or `content` is required}) }
       end
 
-      context 'with ca_text set to valid value' do
-        let(:params) { { ca_text: 'testing' } }
+      context 'with content set to valid value' do
+        let(:params) { { content: 'testing' } }
 
-        it { is_expected.to compile }
-
-        it { is_expected.to contain_ca_cert__ca('ca1') }
-        it { is_expected.to contain_ca_cert__ca('ca2') }
         it { is_expected.to contain_exec('ca_cert_update') }
         it { is_expected.to contain_file('trusted_certs') }
-        it { is_expected.to contain_file('ca1.crt') }
-        it { is_expected.to contain_file('ca2.crt') }
         it { is_expected.to contain_package('ca-certificates') }
 
         it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+          is_expected.to contain_file("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
             {
               'ensure'  => 'file',
               'content' => 'testing',
-              'path'    => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
               'owner'   => 'root',
               'group'   => ca_file_group,
               'mode'    => ca_file_mode,
@@ -60,157 +57,30 @@ describe 'ca_cert::ca', type: :define do
         end
       end
 
-      context 'with source set to valid string "puppet:///testing.crt"' do
-        let(:params) { { source: 'puppet:///testing.crt' } }
-
-        it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-            {
-              'ensure' => 'file',
-              'source' => 'puppet:///testing.crt',
-              'path' => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-              'owner' => 'root',
-              'group' => ca_file_group,
-              'mode' => ca_file_mode,
-              'notify' => 'Exec[ca_cert_update]',
-            }
-          )
-        end
-      end
-
-      context 'with source set to valid string "puppet:///testing.pem"' do
-        let(:params) { { source: 'puppet:///testing.pem' } }
-
-        it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-            {
-              'ensure' => 'file',
-              'source' => 'puppet:///testing.pem',
-              'path' => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-              'owner' => 'root',
-              'group' => ca_file_group,
-              'mode' => ca_file_mode,
-              'notify' => 'Exec[ca_cert_update]',
-            }
-          )
-        end
-      end
-
-      %w[ftp https http].each do |protocol|
-        context "with source set to valid string \"#{protocol}://testing.crt\"" do
-          let(:params) { { source: "#{protocol}://testing.crt" } }
+      {
+        'puppet' => { 'hostname' => nil, 'path' => 'testing.crt' },
+        'file'   => { 'hostname' => nil, 'path' => 'testing.pem' },
+        'ftp'    => { 'hostname' => 'ftp.myorg.com', 'path' => 'testing.crt' },
+        'http'   => { 'hostname' => 'www.myorg.com', 'path' => 'testing.pem' },
+      }.each do |key, values|
+        context "with source set to \"#{key}://#{values['hostname']}/#{values['path']}\"" do
+          let(:params) { { source: "#{key}://#{values['hostname']}/#{values['path']}" } }
 
           it do
-            is_expected.to contain_archive("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+            is_expected.to contain_archive("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
               {
                 'ensure'         => 'present',
-                'source'         => "#{protocol}://testing.crt",
+                'source'         => "#{key}://#{values['hostname']}/#{values['path']}",
                 'checksum'       => nil,
                 'checksum_type'  => nil,
                 'allow_insecure' => false,
+                'before'         => ["File[#{trusted_cert_dir}/#{title}.#{ca_file_extension}]"],
                 'notify'         => 'Exec[ca_cert_update]',
               }
             )
-          end
-        end
-
-        context "with source set to valid string \"#{protocol}://testing.pem\"" do
-          let(:params) { { source: "#{protocol}://testing.pem" } }
-
-          it do
-            is_expected.to contain_archive("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-              {
-                'ensure'         => 'present',
-                'source'         => "#{protocol}://testing.pem",
-                'checksum'       => nil,
-                'checksum_type'  => nil,
-                'allow_insecure' => false,
-                'notify'         => 'Exec[ca_cert_update]',
-              }
-            )
-          end
-        end
-      end
-
-      context 'with source set to valid string "file:/testing.crt"' do
-        let(:params) { { source: 'file:/testing.crt' } }
-
-        it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-            {
-              'ensure' => 'file',
-              'source' => '/testing.crt',
-              'path' => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-              'owner' => 'root',
-              'group' => ca_file_group,
-              'mode' => ca_file_mode,
-              'notify' => 'Exec[ca_cert_update]',
-            }
-          )
-        end
-      end
-
-      context 'with source set to valid string "file:/testing.pem"' do
-        let(:params) { { source: 'file:/testing.pem' } }
-
-        it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-            {
-              'ensure' => 'file',
-              'source' => '/testing.pem',
-              'path' => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-              'owner' => 'root',
-              'group' => ca_file_group,
-              'mode' => ca_file_mode,
-              'notify' => 'Exec[ca_cert_update]',
-            }
-          )
-        end
-      end
-
-      context 'with ensure set to valid string "present"' do
-        let(:params) { { ensure: 'present' } }
-
-        it do
-          is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-            {
-              'ensure'  => 'file',
-              'content' => nil,
-              'path'    => "#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-              'owner'   => 'root',
-              'group'   => ca_file_group,
-              'mode'    => ca_file_mode,
-              'notify'  => 'Exec[ca_cert_update]',
-            }
-          )
-        end
-      end
-
-      context 'with ensure set to valid string "distrusted"' do
-        let(:params) { { ensure: 'distrusted' } }
-
-        it { expect { is_expected.to contain_class(:subject) }.to raise_error(Puppet::Error, %r{ca_text is required if source is set to text}) }
-      end
-
-      context 'with ensure set to valid string "distrusted" when source is "file:/dummy.pem"' do
-        let(:params) { { ensure: 'distrusted', source: 'file:/dummy.pem' } }
-
-        if facts[:os]['family'] == 'Debian'
-          it do
-            is_expected.to contain_file("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
-              {
-                'ensure' => 'absent',
-                'notify' => 'Exec[ca_cert_update]',
-              }
-            )
-          end
-        else
-          it do
-            is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+            is_expected.to contain_file("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
               {
                 'ensure' => 'file',
-                'source' => '/dummy.pem',
-                'path' => "#{distrusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
                 'owner' => 'root',
                 'group' => ca_file_group,
                 'mode' => ca_file_mode,
@@ -221,40 +91,83 @@ describe 'ca_cert::ca', type: :define do
         end
       end
 
-      context 'with ensure set to valid string "distrusted" when ca_text is "testing"' do
-        let(:params) { { ensure: 'distrusted', ca_text: 'testing' } }
+      context 'with ensure set to "trusted"' do
+        let(:params) { { ensure: 'trusted' } }
 
-        if facts[:os]['family'] == 'Debian'
+        it { is_expected.not_to contain_archive("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_exec("trust ca #{title}.#{ca_file_extension}") }
+          it { is_expected.not_to contain_file("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
+        else
+          it { is_expected.not_to contain_exec("#{title}.#{ca_file_extension}") }
+
           it do
-            is_expected.to contain_file("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+            is_expected.to contain_file("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
               {
                 'ensure' => 'absent',
                 'notify' => 'Exec[ca_cert_update]',
               }
             )
           end
+        end
+      end
+
+      context 'with ensure set to "distrusted" and no source or content' do
+        let(:params) { { ensure: 'distrusted' } }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_exec("distrust ca #{title}.#{ca_file_extension}") }
+          it { is_expected.not_to contain_archive("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
+          it { is_expected.not_to contain_file("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
         else
+          it { is_expected.to compile.and_raise_error(%r{Either `source` or `content` is required}) }
+        end
+      end
+
+      context 'with ensure set to "distrusted" and valid source' do
+        let(:params) { { ensure: 'distrusted', source: 'puppet:///testing.crt' } }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_exec("distrust ca #{title}.#{ca_file_extension}") }
+          it { is_expected.not_to contain_archive("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
+          it { is_expected.not_to contain_file("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}") }
+        else
+          it { is_expected.not_to contain_exec("distrust ca #{title}.#{ca_file_extension}") }
+
           it do
-            is_expected.to contain_file("Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+            is_expected.to contain_archive("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
               {
-                'ensure'  => 'file',
-                'content' => 'testing',
-                'path'    => "#{distrusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}",
-                'owner'   => 'root',
-                'group'   => ca_file_group,
-                'mode'    => ca_file_mode,
-                'notify'  => 'Exec[ca_cert_update]',
+                'ensure'         => 'present',
+                'source'         => 'puppet:///testing.crt',
+                'checksum'       => nil,
+                'checksum_type'  => nil,
+                'allow_insecure' => false,
+                'before'         => ["File[#{distrusted_cert_dir}/#{title}.#{ca_file_extension}]"],
+                'notify'         => 'Exec[ca_cert_update]',
+              }
+            )
+            is_expected.to contain_file("#{distrusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
+              {
+                'ensure' => 'file',
+                'owner' => 'root',
+                'group' => ca_file_group,
+                'mode' => ca_file_mode,
+                'notify' => 'Exec[ca_cert_update]',
               }
             )
           end
         end
       end
 
-      context 'with ensure set to valid string "absent"' do
+      context 'with ensure set to "absent"' do
         let(:params) { { ensure: 'absent' } }
 
         it do
-          is_expected.to contain_file("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").only_with(
+          is_expected.to contain_file("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").only_with(
             {
               'ensure' => 'absent',
               'notify' => 'Exec[ca_cert_update]',
@@ -263,24 +176,22 @@ describe 'ca_cert::ca', type: :define do
         end
       end
 
-      %w[ftp https http].each do |protocol|
-        context "with verify_https_cert set to valid false when source set to valid string \"#{protocol}://testing.pem\"" do
-          let(:params) { { verify_https_cert: false, source: "#{protocol}://testing.pem" } }
+      context 'with allow_insecure_source set to true' do
+        let(:params) { { allow_insecure_source: true, source: 'https://www.myorg.com/testing.pem' } }
 
-          it { is_expected.to contain_archive("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").with_allow_insecure(true) }
-        end
+        it { is_expected.to contain_archive("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").with_allow_insecure(true) }
+      end
 
-        context "with checksum set to valid value when source set to valid string \"#{protocol}://testing.pem\"" do
-          let(:params) { { checksum: 'testing', source: "#{protocol}://testing.pem" } }
+      context 'with checksum' do
+        let(:params) { { checksum: 'testing', source: 'https://www.myorg.com/testing.pem' } }
 
-          it { is_expected.to contain_archive("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").with_checksum('testing') }
-        end
+        it { is_expected.to contain_archive("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").with_checksum('testing') }
+      end
 
-        context "with checksum_type set to valid value when source set to valid string \"#{protocol}://testing.pem\"" do
-          let(:params) { { checksum_type: 'testing', source: "#{protocol}://testing.pem" } }
+      context 'with checksum_type' do
+        let(:params) { { checksum_type: 'testing', source: 'https://www.myorg.com/testing.pem' } }
 
-          it { is_expected.to contain_archive("#{trusted_cert_dir}/Globalsign_Org_Intermediate.#{ca_file_extension}").with_checksum_type('testing') }
-        end
+        it { is_expected.to contain_archive("#{trusted_cert_dir}/#{title}.#{ca_file_extension}").with_checksum_type('testing') }
       end
     end
   end

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -15,7 +15,11 @@ describe 'ca_cert::ca', type: :define do
       trusted_cert_dir    = '/usr/local/share/ca-certificates'
     when 'RedHat'
       trusted_cert_dir    = '/etc/pki/ca-trust/source/anchors'
-      distrusted_cert_dir = '/etc/pki/ca-trust/source/blacklist'
+      distrusted_cert_dir = if facts[:os]['release']['major'] < '9'
+                              '/etc/pki/ca-trust/source/blacklist'
+                            else
+                              '/etc/pki/ca-trust/source/blocklist'
+                            end
     when 'Archlinux'
       trusted_cert_dir    = '/etc/ca-certificates/trust-source/anchors'
       distrusted_cert_dir = '/etc/ca-certificates/trust-source/blacklist'

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -22,7 +22,7 @@ describe 'ca_cert::ca', type: :define do
                             end
     when 'Archlinux'
       trusted_cert_dir    = '/etc/ca-certificates/trust-source/anchors'
-      distrusted_cert_dir = '/etc/ca-certificates/trust-source/blacklist'
+      distrusted_cert_dir = '/etc/ca-certificates/trust-source/blocklist'
     when 'Suse'
       trusted_cert_dir    = '/etc/pki/trust/anchors'
       distrusted_cert_dir = '/etc/pki/trust/blacklist'


### PR DESCRIPTION
#### Pull Request (PR) description
Rework of ca_cert::ca to support trusting and distrusting ca's provided by the ca-certificates package on Debian.
Also makes it possible to move from distrusted to trusted again on other distros ( ensure absent from `distrusted_cert_dir`)

To support this I have redefined the meaning of ca_cert::ca::ensure a bit
- present/absent is now used to manage certificates in `trusted_cert_dir`
- trusted/distrusted is now used to manage certificates in `distrusted_cert_dir` og Debian's `ca_certificates_conf`

`ca_cert::ca::ca_text`is renamed to `ca_cert::ca::content`and used directly as `file::content`
`ca_cert::ca::source` is now used directly as `archive::source`

`ca_cert::ca::verify_https_cert` parameter is renamed to `ca_cert::ca::allow_insecure_source` to better align with `archive::allow_insecure`
 
#### This Pull Request (PR) fixes the following issues
Fixes #96 
