### PR TITLE
Support proxy when downloading remote certificates

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -220,11 +220,13 @@ ca_cert::ca { 'globalsign_org_intermediate':
 The following parameters are available in the `ca_cert::ca` defined type:
 
 * [`ensure`](#-ca_cert--ca--ensure)
-* [`content`](#-ca_cert--ca--content)
-* [`source`](#-ca_cert--ca--source)
 * [`allow_insecure_source`](#-ca_cert--ca--allow_insecure_source)
+* [`source`](#-ca_cert--ca--source)
+* [`content`](#-ca_cert--ca--content)
 * [`checksum`](#-ca_cert--ca--checksum)
 * [`checksum_type`](#-ca_cert--ca--checksum_type)
+* [`proxy_server`](#-ca_cert--ca--proxy_server)
+* [`proxy_type`](#-ca_cert--ca--proxy_type)
 
 ##### <a name="-ca_cert--ca--ensure"></a>`ensure`
 
@@ -236,14 +238,13 @@ Whether or not the CA certificate should be on a system or not.
 
 Default value: `'present'`
 
-##### <a name="-ca_cert--ca--content"></a>`content`
+##### <a name="-ca_cert--ca--allow_insecure_source"></a>`allow_insecure_source`
 
-Data type: `Optional[String[1]]`
+Data type: `Boolean`
 
-PEM formatted certificate content
-This attribute is mutually exclusive with `source`
+Whether to allow insecure download or not.
 
-Default value: `undef`
+Default value: `false`
 
 ##### <a name="-ca_cert--ca--source"></a>`source`
 
@@ -255,19 +256,20 @@ Uri support, see puppet-archive.
 
 Default value: `undef`
 
-##### <a name="-ca_cert--ca--allow_insecure_source"></a>`allow_insecure_source`
+##### <a name="-ca_cert--ca--content"></a>`content`
 
-Data type: `Boolean`
+Data type: `Optional[String[1]]`
 
-Wether to allow insecure download or not.
+PEM formatted certificate content
+This attribute is mutually exclusive with `source`
 
-Default value: `false`
+Default value: `undef`
 
 ##### <a name="-ca_cert--ca--checksum"></a>`checksum`
 
 Data type: `Optional[String[1]]`
 
-The checksum of the file. (defaults to undef)
+The checksum of the file.
 
 Default value: `undef`
 
@@ -275,7 +277,23 @@ Default value: `undef`
 
 Data type: `Optional[String[1]]`
 
-The type of file checksum. (defauts to undef)
+The type of file checksum.
+
+Default value: `undef`
+
+##### <a name="-ca_cert--ca--proxy_server"></a>`proxy_server`
+
+Data type: `Optional[String[1]]`
+
+Proxy address to use when accessing source
+
+Default value: `undef`
+
+##### <a name="-ca_cert--ca--proxy_type"></a>`proxy_type`
+
+Data type: `Optional[String[1]]`
+
+Proxy type ( See `archive::proxy_type )
 
 Default value: `undef`
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -11,23 +11,29 @@
 #   - `present`/`absent` is used to manage local/none default CAs.
 #   - `trusted`/`distrusted` is used to manage system CAs.
 #
-# @param content
-#   PEM formatted certificate content
-#   This attribute is mutually exclusive with `source`
+# @param allow_insecure_source
+#   Whether to allow insecure download or not.
 #
 # @param source
 #   A source certificate, which will be copied into place on the local system.
 #   This attribute is mutually exclusive with `content`
 #   Uri support, see puppet-archive.
 #
-# @param allow_insecure_source
-#   Wether to allow insecure download or not.
+# @param content
+#   PEM formatted certificate content
+#   This attribute is mutually exclusive with `source`
 #
 # @param checksum
-#   The checksum of the file. (defaults to undef)
+#   The checksum of the file.
 #
 # @param checksum_type
-#   The type of file checksum. (defauts to undef)
+#   The type of file checksum.
+#
+# @param proxy_server
+#   Proxy address to use when accessing source
+#
+# @param proxy_type
+#   Proxy type ( See `archive::proxy_type )
 #
 define ca_cert::ca (
   Enum['present', 'absent', 'trusted', 'distrusted'] $ensure = 'present',
@@ -36,6 +42,8 @@ define ca_cert::ca (
   Optional[String[1]] $content = undef,
   Optional[String[1]] $checksum = undef,
   Optional[String[1]] $checksum_type = undef,
+  Optional[String[1]] $proxy_server = undef,
+  Optional[String[1]] $proxy_type = undef,
 ) {
   include ca_cert
 
@@ -80,6 +88,8 @@ define ca_cert::ca (
             checksum       => $checksum,
             checksum_type  => $checksum_type,
             allow_insecure => $allow_insecure_source,
+            proxy_server   => $proxy_server,
+            proxy_type     => $proxy_type,
             notify         => Exec['ca_cert_update'],
           }
           -> file { $ca_cert:


### PR DESCRIPTION

#### Pull Request (PR) description
Adding params to ca_cer::ca so that remote certificates can be downloaded truogh a proxy

#### This Pull Request (PR) fixes the following issues
Fixes #46 
